### PR TITLE
upgrade loader-utils, parseQuery => getOptions

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "async": "^2.1.4",
     "chalk": "^1.1.3",
     "glob": "^7.1.1",
-    "loader-utils": "^0.2.16"
+    "loader-utils": "^1.0.4"
   },
   "devDependencies": {
     "babel": "^6.1.18",

--- a/src/loader.js
+++ b/src/loader.js
@@ -21,11 +21,21 @@ module.exports = function(source) {
   logger.debug(`Hey, we're in DEBUG mode! Yabba dabba doo!`);
 
   // TODO: Remove `webpack.options.sassResources` support after first stable webpack@2 release
+  const isWebpack2 = webpack.version === 2;
   const resourcesFromConfig =
-    webpack.version !== 2
-    ? webpack.options.sassResources
-    : (loaderUtils.getOptions(this) || { resources: undefined }).resources
-  ;
+    isWebpack2
+    ? (loaderUtils.getOptions(this) || {}).resources
+    : webpack.options.sassResources;
+
+  if (!resourcesFromConfig) {
+    const error = new Error(`
+      Can't find sass resources in your config.
+      Make sure ${isWebpack2 ? 'loader.options.resources' : 'webpackConfig.sassResources'} exists.
+    `);
+
+    return callback(error);
+  }
+
   const resourcesLocations = parseResources(resourcesFromConfig);
   const moduleContext = webpack.context;
   const webpackConfigContext = webpack.options.context || process.cwd();

--- a/src/loader.js
+++ b/src/loader.js
@@ -24,7 +24,7 @@ module.exports = function(source) {
   const resourcesFromConfig =
     webpack.version !== 2
     ? webpack.options.sassResources
-    : loaderUtils.parseQuery(this.query).resources
+    : (loaderUtils.getOptions(this) || { resources: undefined }).resources
   ;
   const resourcesLocations = parseResources(resourcesFromConfig);
   const moduleContext = webpack.context;


### PR DESCRIPTION
Here is the PR for  #28 

Previously parseQuery would return an empty object if given nothing, but now getOptions returns null if given nothing, so I added the `|| {}` to fix it!

Let me know if you need anything!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shakacode/sass-resources-loader/29)
<!-- Reviewable:end -->
