### PR TITLE
Rewrite @import paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Change Log
 ## [Unreleased]
+* Added support for `@import` rules in resource files [#34](https://github.com/shakacode/sass-resources-loader/pull/34) by [coditect](https://github.com/coditect)
 
 ## [1.1.0]
 #### Added

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ $section-width: 700px;
 
 **NB!**
 * Do not include anything that will be actually rendered in CSS, because it will be added to every imported SASS file.
-* Do not use SASS `@import` inside resources files. Add imported files directly in `sassResources` array in webpack config instead.
+* Avoid using SASS `@import` rules inside resources files. Add imported files directly in `sassResources` array in webpack config instead.
 
 Apply loader in webpack config (`v1.x.x` & `v2.x.x` are supported) and provide path to the file with resources:
 

--- a/example/app/assets/styles/mixins.scss
+++ b/example/app/assets/styles/mixins.scss
@@ -1,3 +1,2 @@
-@mixin center-text {
-  text-align: center;
-}
+@import 'mixins/centerText';
+@import 'mixins/fullWidth';

--- a/example/app/assets/styles/mixins/centerText.scss
+++ b/example/app/assets/styles/mixins/centerText.scss
@@ -1,0 +1,3 @@
+@mixin center-text {
+  text-align: center;
+}

--- a/example/app/assets/styles/mixins/fullWidth.scss
+++ b/example/app/assets/styles/mixins/fullWidth.scss
@@ -1,0 +1,3 @@
+@mixin full-width {
+  width: 100%;
+}

--- a/example/app/components/Hero/Hero.scss
+++ b/example/app/components/Hero/Hero.scss
@@ -1,7 +1,7 @@
 .hero {
   @include center-text;
+  @include full-width;
   margin-bottom: 50px;
-  width: 100%;
   height: 70vh;
   background-color: $background-color;
   color: $text-color;

--- a/example/app/layout/Layout.scss
+++ b/example/app/layout/Layout.scss
@@ -4,7 +4,7 @@
 }
 
 .layout {
+  @include full-width;
   display: block;
   position: relative;
-  width: 100%;
 }

--- a/example/webpack.config.js
+++ b/example/webpack.config.js
@@ -47,7 +47,10 @@ module.exports = {
           {
             loader: 'sass-resources-loader',
             options: {
-              resources: './app/assets/styles/**/*.scss',
+              resources: [
+                './app/assets/styles/variables/*.scss',
+                './app/assets/styles/mixins.scss',
+              ],
             },
           },
         ],

--- a/example/webpack.prod.config.js
+++ b/example/webpack.prod.config.js
@@ -43,7 +43,12 @@ module.exports = {
             'sass-loader',
             {
               loader: 'sass-resources-loader',
-              query: { resources: './app/assets/styles/**/*.scss' },
+              query: {
+                resources: [
+                  './app/assets/styles/variables/*.scss',
+                  './app/assets/styles/mixins.scss',
+                ],
+              },
             },
           ],
         }),

--- a/src/loader.js
+++ b/src/loader.js
@@ -7,6 +7,7 @@ import loaderUtils from 'loader-utils';
 
 import processResources from './utils/processResources';
 import parseResources from './utils/parseResources';
+import rewriteImports from './utils/rewriteImports';
 import logger from './utils/logger';
 
 module.exports = function(source) {
@@ -68,7 +69,11 @@ module.exports = function(source) {
 
   async.map(
     files,
-    (file, cb) => fs.readFile(file, 'utf8', cb),
+    (file, cb) => {
+      fs.readFile(file, 'utf8', (error, contents) => {
+        rewriteImports(error, file, contents, moduleContext, cb);
+      });
+    },
     (error, resources) => {
       processResources(error, resources, source, moduleContext, callback);
     }

--- a/src/utils/rewriteImports.js
+++ b/src/utils/rewriteImports.js
@@ -1,0 +1,27 @@
+import path from 'path';
+
+import logger from './logger';
+
+const importRegexp = /@import\s+(?:'([^']+)'|"([^"]+)"|([^\s;]+))/g;
+
+export default (error, file, contents, moduleContext, callback) => {
+  if (error) {
+    logger.debug('Resources: **not found**');
+    return callback(error);
+  }
+
+  const rewritten = contents.replace(importRegexp, (entire, single, double, unquoted) => {
+    const oldImportPath = single || double || unquoted;
+    const absoluteImportPath = path.join(path.dirname(file), oldImportPath);
+    const newImportPath = path.relative(moduleContext, absoluteImportPath);
+
+    logger.debug(`Resources: @import of ${oldImportPath} changed to ${newImportPath}`);
+
+    const lastCharacter = entire[entire.length - 1];
+    const quote = lastCharacter === "'" || lastCharacter === '"' ? lastCharacter : '';
+
+    return `@import ${quote}${newImportPath}${quote}`;
+  });
+
+  callback(null, rewritten);
+};

--- a/src/utils/rewriteImports.js
+++ b/src/utils/rewriteImports.js
@@ -10,6 +10,10 @@ export default (error, file, contents, moduleContext, callback) => {
     return callback(error);
   }
 
+  if (!/\.s[ac]ss$/i.test(file)) {
+    return callback(null, contents);
+  }
+
   const rewritten = contents.replace(importRegexp, (entire, single, double, unquoted) => {
     const oldImportPath = single || double || unquoted;
     const absoluteImportPath = path.join(path.dirname(file), oldImportPath);


### PR DESCRIPTION
The documentation for `sass-resources-loader` makes it quite clear that `@import` rules are not allowed in resource files.  However, I have found them to be unavoidable when working with [Foundation for Sites](http://foundation.zurb.com/sites.html).  My changes give `sass-resources-loader` the ability to rewrite the paths of any `@import` rules found in resource files so that `sass-loader` can resolve those imports later in the build process.

Potential issues:
- No attempt it made to escape disallowed characters in the rewritten import paths.
- ~~Not compatible with [import directives](http://lesscss.org/features/#import-options) in LESS.~~ Workaround provided in 6582c4e.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shakacode/sass-resources-loader/34)
<!-- Reviewable:end -->
