### PR TITLE
Fix for error loading resources on windows.

### DIFF
--- a/src/utils/rewriteImports.js
+++ b/src/utils/rewriteImports.js
@@ -4,7 +4,7 @@ import logger from './logger';
 
 const importRegexp = /@import\s+(?:'([^']+)'|"([^"]+)"|([^\s;]+))/g;
 
-export const getNewImportPath = (oldImportPath, absoluteImportPath, moduleContext) => {
+export const getRelativeImportPath = (oldImportPath, absoluteImportPath, moduleContext) => {
   // from node_modules
   if ((/^\~/).test(oldImportPath)) {
     return oldImportPath;
@@ -27,7 +27,8 @@ export default (error, file, contents, moduleContext, callback) => {
     const oldImportPath = single || double || unquoted;
 
     const absoluteImportPath = path.join(path.dirname(file), oldImportPath);
-    const newImportPath = getNewImportPath(oldImportPath, absoluteImportPath, moduleContext);
+    const relImportPath = getRelativeImportPath(oldImportPath, absoluteImportPath, moduleContext);
+    const newImportPath = relImportPath.split(path.sep).join('/');
     logger.debug(`Resources: @import of ${oldImportPath} changed to ${newImportPath}`);
 
     const lastCharacter = entire[entire.length - 1];


### PR DESCRIPTION
Fixes issue where using Node 'path.relative' injects OS specific path separator - but should continue to use '/' as used in CSS. See https://github.com/shakacode/sass-resources-loader/issues/41.

Has been tested on Mac / PC / Linux.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shakacode/sass-resources-loader/42)
<!-- Reviewable:end -->
