### PR TITLE
Support webpack@4's `rootContext` property

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "lint": "scripts/lint",
     "test": "jest",
     "clean": "scripts/clean",
-    "prerelease": "npm run test && npm run lint && npm run clean && npm run build",
+    "prerelease": "npm run clean && npm run build && npm run test && npm run lint",
     "preversion": "npm run prerelease",
     "prepublish": "npm run prerelease",
     "release:patch": "scripts/release patch",

--- a/src/loader.js
+++ b/src/loader.js
@@ -39,9 +39,9 @@ module.exports = function(source) {
 
   const resourcesLocations = parseResources(resourcesFromConfig);
   const moduleContext = webpack.context;
-  const webpackConfigContext = webpack.options.context || process.cwd();
+  const webpackConfigContext = webpack.rootContext || (webpack.options && webpack.options.context) || process.cwd();
 
-  if (!webpack.options || !webpack.options.context) {
+  if (!webpack.rootContext && !webpack.options && !webpack.options.context) {
     logger.log(
       '`options.context` is missing. Using current working directory as a root instead:',
       process.cwd(),

--- a/src/loader.js
+++ b/src/loader.js
@@ -42,7 +42,7 @@ module.exports = function(source) {
   const webpackConfigContext = webpack.rootContext || (webpack.options && webpack.options.context) || process.cwd();
 
   if (!webpack.rootContext && !webpack.options && !webpack.options.context) {
-    logger.log(
+    logger.debug(
       '`options.context` is missing. Using current working directory as a root instead:',
       process.cwd(),
     );


### PR DESCRIPTION
More details [in the webpack migration guide](https://medium.com/webpack/webpack-4-migration-guide-for-plugins-loaders-20a79b927202#3ab1):

> webpack 3 already deprecated this.options in the loader context. webpack 4 removes it now.
> A lot of people are missing the this.options.context value now. It has been added as this.rootContext.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shakacode/sass-resources-loader/59)
<!-- Reviewable:end -->
