### PR TITLE
Add doc for usage in Vue Webpack template

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,22 @@ Note that `sass-resources-loader` will resolve your files in order. If you want 
 resources: [ './path/to/variables/vars.scss', './path/to/mixins/**/*.scss' ]
 ```
 
+
+### VueJS webpack template
+
+If you wish to use this loader in the [VueJS Webpack template](https://github.com/vuejs-templates/webpack) you need to add the following code in ````build/utils.js```` after line 42 :
+
+```js
+if (loader === 'sass') {
+  loaders.push({
+    loader: 'sass-resources-loader',
+    options: {
+      resources: 'path/to/your/file.scss',
+    },
+  });
+}
+```
+
 ## Contributing
 This project is intended to be a safe, welcoming space for collaboration, and contributors are expected to adhere to the [code of conduct](CODE_OF_CONDUCT.md).
 


### PR DESCRIPTION
As said in #67, I added the solution for using the loader in the Vue Webpack template

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shakacode/sass-resources-loader/69)
<!-- Reviewable:end -->
