### PR TITLE
Add example of config in README about vue-cli@3

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ if (loader === 'sass') {
 
 ### VueJS webpack template(vue-cli@3)
 
-If you are using vue-cli@3, you need create a `vue.config.js` file in your project root(next to package.json).then, add the following code :
+If you are using vue-cli@3, you need create a `vue.config.js` file in your project root(next to package.json). Then, add the following code :
 
 ```js
 // vue.config.js

--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ resources: [ './path/to/variables/vars.scss', './path/to/mixins/**/*.scss' ]
 ```
 
 
-### VueJS webpack template
+### VueJS webpack template(vue-cli@2)
 
 If you wish to use this loader in the [VueJS Webpack template](https://github.com/vuejs-templates/webpack) you need to add the following code in ````build/utils.js```` after line 42 :
 
@@ -188,6 +188,33 @@ if (loader === 'sass') {
   });
 }
 ```
+
+### VueJS webpack template(vue-cli@3)
+
+If you are using vue-cli@3, you need create a `vue.config.js` file in your project root(next to package.json).then, add the following code :
+
+```js
+// vue.config.js
+module.exports = {
+  chainWebpack: config => {
+    const oneOfsMap = config.module.rule('scss').oneOfs.store
+    oneOfsMap.forEach(item => {
+      item
+        .use('sass-resources-loader')
+        .loader('sass-resources-loader')
+        .options({
+          // Provide path to the file with resources
+          resources: './path/to/resources.scss',
+
+          // Or array of paths
+          resources: ['./path/to/vars.scss', './path/to/mixins.scss']
+        })
+        .end()
+    })
+  }
+}
+```
+
 
 ## Contributing
 This project is intended to be a safe, welcoming space for collaboration, and contributors are expected to adhere to the [code of conduct](CODE_OF_CONDUCT.md).


### PR DESCRIPTION
It's very convenient when write `Sass` with `sass-resources-loader` —— no `@import`. Thanks for your work! But, it's quite painful for `vue` users who is not familiar with `webpack` to config the loader. I find out that there is an example about `vue-cli@2` in the README.Since `vue-cli@3` has been publish for a lot time and more and more users are trying to update to it, I think it's time to add example of config about vue-cli@3. Obviously, it's more complex.Hope can help the person in need and increase the amount of `sass-resources-loader` users. If you want to test if the example is correct, you can clone this [repo](https://github.com/HaoChuan9421/vue-cli3-optimization) and try it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shakacode/sass-resources-loader/77)
<!-- Reviewable:end -->
