### PR TITLE
De-duplicate hoisted imports and avoid rewriting imports of built-ins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Change Log
-## [Unreleased]
+## [2.2.2] - Unreleased
+* De-duplicate hoisted imports and avoid rewriting imports of built-ins. [#142](https://github.com/shakacode/sass-resources-loader/pull/142) by [Jan Amann](https://github.com/amannn).
 
 ## [2.2.1] - 2021-04-14
 * Support multi-line imports with @use syntax. Fixes: [#135](https://github.com/shakacode/sass-resources-loader/issues/135). [#140](https://github.com/shakacode/sass-resources-loader/pull/140) by [Toms Burgmanis](https://github.com/tomburgs).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sass-resources-loader",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "description": "SASS resources loader for Webpack",
   "main": "lib/loader.js",
   "files": [

--- a/src/utils/processResources.js
+++ b/src/utils/processResources.js
@@ -9,12 +9,23 @@ const useRegexTest = new RegExp(useRegex, 'm');
 // Makes sure that only the last instance of `useRegex` variable is found
 const useRegexReplace = new RegExp(`${useRegex}(?![\\s\\S]*${useRegex})`, 'gm');
 
-const getOutput = (source, resources, { hoistUseStatements }) => {
+export const getOutput = (source, resources, { hoistUseStatements }) => {
   if (hoistUseStatements && useRegexTest.test(source)) {
-    return source.replace(
+    const output = source.replace(
       useRegexReplace,
-      useStatements => `${useStatements}\n${resources}`,
+      (useStatements) => `${useStatements}\n${resources}`,
     );
+
+    // De-duplicate identical imports
+    const importedResources = {};
+    return output.replace(new RegExp(useRegex, 'mg'), (importedResource) => {
+      if (importedResources[importedResource]) {
+        return '';
+      }
+
+      importedResources[importedResource] = true;
+      return importedResource;
+    });
   }
 
   return `${resources}\n${source}`;

--- a/src/utils/rewritePaths.js
+++ b/src/utils/rewritePaths.js
@@ -22,8 +22,12 @@ export default function rewritePaths(error, file, contents, moduleContext, callb
     return callback(null, contents);
   }
 
-
   const rewritten = contents.replace(useRegexp, (entire, importer, single, double, unquoted) => {
+    // Don't rewrite imports from built-ins
+    if (single.indexOf('sass:') === 0) {
+      return entire;
+    }
+
     const oldUsePath = single || double || unquoted;
 
     const absoluteUsePath = path.join(path.dirname(file), oldUsePath);

--- a/test/__snapshots__/index.test.js.snap
+++ b/test/__snapshots__/index.test.js.snap
@@ -98,6 +98,20 @@ div {
 "
 `;
 
+exports[`sass-resources-loader imports should not rewrite the path for built-ins with @use 1`] = `
+"// Should be de-duplicated
+@use 'sass:math';
+
+
+$padding: #{math.div(4 / 2)}px;
+
+div {
+    padding: $padding;
+    margin: #{math.div(4 / 2)}px;;
+}
+"
+`;
+
 exports[`sass-resources-loader imports should preserve import method 1`] = `
 "@use 'shared/index' as secret;
 @import 'shared/variables';
@@ -125,6 +139,10 @@ exports[`sass-resources-loader resources should parse array resources 1`] = `
 @import 'shared/variables';
 
 @forward \\"variables\\";
+
+@use 'sass:math';
+
+$padding: #{math.div(4 / 2)}px;
 
 $text-color: $ccc;
 

--- a/test/scss/shared/_math.scss
+++ b/test/scss/shared/_math.scss
@@ -1,0 +1,3 @@
+@use 'sass:math';
+
+$padding: #{math.div(4 / 2)}px;

--- a/test/scss/use-builtin.scss
+++ b/test/scss/use-builtin.scss
@@ -1,0 +1,7 @@
+// Should be de-duplicated
+@use 'sass:math';
+
+div {
+    padding: $padding;
+    margin: #{math.div(4 / 2)}px;;
+}


### PR DESCRIPTION
Since [division with `/` is being deprecated](https://sass-lang.com/documentation/breaking-changes/slash-div) I stumbled upon two issues while moving to `sass:math` with `sass-resources-loader`.

This PR addresses both of them:
- Hoisted imports should be de-duplicated so SASS doesn't throw. I'd argue that this is necessary, since an individual style sheet can't know which imports are used in a resource and also shouldn't rely on them.
- Imports to built-ins from SASS shouldn't be rewritten.

I've tested the changes from this PR locally in my project and everything worked fine then.

Thank you for maintaining `sass-resources-loader`!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shakacode/sass-resources-loader/142)
<!-- Reviewable:end -->
