### PR TITLE
Supported double quoted use imports from built-ins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Change Log
+## [2.2.4] - Unreleased
+* Support double quoted imports of built-ins. [#145](https://github.com/shakacode/sass-resources-loader/pull/147) by [Jan Amann](https://github.com/amannn).
+
 ## [2.2.3] - 2021-06-21
 * Fix regression introduced in 2.2.2 for "causes TypeError: Cannot read property 'indexOf' of undefined". [#145](https://github.com/shakacode/sass-resources-loader/pull/145) by [Juan Antonio Gómez](https://github.com/shokmaster).
 

--- a/src/utils/rewritePaths.js
+++ b/src/utils/rewritePaths.js
@@ -24,7 +24,7 @@ export default function rewritePaths(error, file, contents, moduleContext, callb
 
   const rewritten = contents.replace(useRegexp, (entire, importer, single, double, unquoted) => {
     // Don't rewrite imports from built-ins
-    if (single && single.indexOf('sass:') === 0) {
+    if ([single, double].some(match => match && match.indexOf('sass:') === 0)) {
       return entire;
     }
 

--- a/test/__snapshots__/index.test.js.snap
+++ b/test/__snapshots__/index.test.js.snap
@@ -112,6 +112,20 @@ div {
 "
 `;
 
+exports[`sass-resources-loader imports should not rewrite the path for built-ins with @use and double quotes 1`] = `
+"// Should be de-duplicated
+@use 'sass:math';
+
+
+$padding: #{math.div(4 / 2)}px;
+
+div {
+    padding: $padding;
+    margin: #{math.div(4 / 2)}px;;
+}
+"
+`;
+
 exports[`sass-resources-loader imports should preserve import method 1`] = `
 "@use 'shared/index' as secret;
 @import 'shared/variables';
@@ -139,6 +153,10 @@ exports[`sass-resources-loader resources should parse array resources 1`] = `
 @import 'shared/variables';
 
 @forward \\"variables\\";
+
+@use \\"sass:math\\";
+
+$padding: #{math.div(4 / 2)}px;
 
 @use 'sass:math';
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -252,6 +252,17 @@ describe('sass-resources-loader', () => {
       const output = require('./output/use-builtin').default;
       expect(output).toMatchSnapshot();
     }));
+
+    it('should not rewrite the path for built-ins with @use and double quotes', () => execTest('use-builtin', {
+      hoistUseStatements: true,
+      resources: [
+        path.resolve(__dirname, './scss/shared/_math-double-quotes.scss'),
+      ],
+    }).then(() => {
+      // eslint-disable-next-line global-require
+      const output = require('./output/use-builtin').default;
+      expect(output).toMatchSnapshot();
+    }));
   });
 
   describe('getOutput', () => {

--- a/test/scss/shared/_math-double-quotes.scss
+++ b/test/scss/shared/_math-double-quotes.scss
@@ -1,0 +1,3 @@
+@use "sass:math";
+
+$padding: #{math.div(4 / 2)}px;


### PR DESCRIPTION
@justin808 Related to https://github.com/shakacode/sass-resources-loader/pull/142, I noticed double quotes need to be handled separately.

Also sorry for the subtle bug that slipped in in #142!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shakacode/sass-resources-loader/147)
<!-- Reviewable:end -->
