### PR TITLE
Update async to v3.2.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "webpack"
   ],
   "dependencies": {
-    "async": "^3.2.0",
+    "async": "^3.2.3",
     "chalk": "^4.1.0",
     "glob": "^7.1.6",
     "loader-utils": "^2.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1572,10 +1572,10 @@ async-each@^1.0.1:
   resolved "https://registry.yarnpkg.com/async-each/-/async-each-1.0.3.tgz#b727dbf87d7651602f06f4d4ac387f47d91b0cbf"
   integrity sha512-z/WhQ5FPySLdvREByI2vZiTWwCnF0moMJ1hK9YQwDTHKh6I7/uSckMetoRGb5UBZPC1z0jlw+n/XCgjeH7y1AQ==
 
-async@^3.2.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/async/-/async-3.2.0.tgz#b3a2685c5ebb641d3de02d161002c60fc9f85720"
-  integrity sha512-TR2mEZFVOj2pLStYxLht7TyfuRzaydfpxr3k9RpHIzMgw7A64dzsdqCxH1WJyQdoe8T10nDXd9wnEigmiuHIZw==
+async@^3.2.3:
+  version "3.2.3"
+  resolved "https://registry.yarnpkg.com/async/-/async-3.2.3.tgz#ac53dafd3f4720ee9e8a160628f18ea91df196c9"
+  integrity sha512-spZRyzKL5l5BZQrr/6m/SqFdBN0q3OCI0f9rjfBzCMBIP4p75P620rR3gTmaksNOhmzgdxcaxdNfMy6anrbM0g==
 
 asynckit@^0.4.0:
   version "0.4.0"


### PR DESCRIPTION
Fix for #153, update `async` to 3.2.3.

Post update:
```
yarn install v1.22.18
[1/4] Resolving packages...
success Already up-to-date.
$ yarn run prerelease
yarn run v1.22.18
$ yarn run clean && yarn run build && yarn run test && yarn run lint
$ scripts/clean
$ scripts/build
Browserslist: caniuse-lite is outdated. Please run:
npx browserslist@latest --update-db
Successfully compiled 9 files with Babel (429ms).
$ jest
 PASS  test/index.test.js
  sass-resources-loader
    resources
      ✓ should parse resource (494 ms)
      ✓ should parse array resources (25 ms)
      ✓ should include resources (38 ms)
      ✓ should throw error when no resources provided (34 ms)
      ✓ should throw error when resources are empty (16 ms)
      ✓ should throw error when resources glob did not resolve any files (11 ms)
      ✓ should throw error when no files were resolved from any resource globs (28 ms)
    hoisting
      ✓ should hoist entry @use imports when option hoistUseStatements is true (34 ms)
      ✓ should not hoist entry @use imports when option hoistUseStatements is false (20 ms)
      ✓ should not hoist entry @use imports when option hoistUseStatements is not passed (40 ms)
      ✓ should work with multiline @use statements (14 ms)
    imports
      ✓ should not rewrite path for imports with ~ (1 ms)
      ✓ should preserve import method (10 ms)
      ✓ should not rewrite the path for built-ins with @use (13 ms)
      ✓ should not rewrite the path for built-ins with @use and double quotes (36 ms)
    getOutput
      ✓ de-duplicates imports from the source when they're present in a resource and `hoiseUseStatements` is enabled (1 ms)

Test Suites: 1 passed, 1 total
Tests:       16 passed, 16 total
Snapshots:   10 passed, 10 total
Time:        1.342 s, estimated 3 s
Ran all test suites.
Jest did not exit one second after the test run has completed.

This usually means that there are asynchronous operations that weren't stopped in your tests. Consider running Jest with `--detectOpenHandles` to troubleshoot this issue.
$ scripts/lint
Done in 5.08s.
Done in 5.44s.
```