### PR TITLE
Update node.js.yml

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -26,4 +26,4 @@ jobs:
       with:
         node-version: ${{ matrix.node-version }}
         cache: 'yarn'
-    - run: yarn install --frozen-lockfile
+    - run: yarn install


### PR DESCRIPTION
Remove --frozen-lockfile flag.
This flag prevents tests to success while upgrading dependencies, because `yarn install` in tests needs to update `yarn.lock`.