### PR TITLE
Extend ESLint to test example

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,4 +1,3 @@
 node_modules/
 lib/
-example/
 test/output

--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -6,4 +6,10 @@ globals:
 
 env:
   jest: true
+  browser: true
 
+parser: babel-eslint
+settings:
+  import/resolver:
+    node:
+      map: ['@', './example']

--- a/scripts/lint
+++ b/scripts/lint
@@ -1,5 +1,5 @@
 #!/bin/sh
 
 $(npm bin)/eslint \
-  --ext .js \
+  --ext .js,.jsx \
   .


### PR DESCRIPTION
ESLint does not run to check components of `example`. In one of the previous PRs I fixed ESLint issues in `example` and now I am adding ESLint checks to them, so we should still be green.