### PR TITLE
Add checks/statuses read permissions to Claude workflow

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -24,6 +24,8 @@ jobs:
       issues: read
       id-token: write
       actions: read # Required for Claude to read CI results on PRs
+      checks: read
+      statuses: read
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -34,11 +36,14 @@ jobs:
         id: claude
         uses: anthropics/claude-code-action@v1
         with:
+          github_token: ${{ github.token }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 
           # This is an optional setting that allows Claude to read CI results on PRs
           additional_permissions: |
             actions: read
+            checks: read
+            statuses: read
 
           # Optional: Give a custom prompt to Claude. If this is not specified, Claude will perform the instructions specified in the comment that tagged it.
           # prompt: 'Update the pull request description to include a summary of changes.'


### PR DESCRIPTION
Applies the workflow update from [shakacode/react_on_rails#2487](https://github.com/shakacode/react_on_rails/pull/2487):

- add `checks: read` and `statuses: read` to job permissions
- pass `github_token: ${{ github.token }}` to `anthropics/claude-code-action`
- add `checks: read` and `statuses: read` to `additional_permissions`

Admin merge requested to keep rollout fast across repos.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk workflow-only change that expands GitHub token permissions to read `checks`/`statuses`, which could expose additional CI metadata if misused but does not affect application runtime.
> 
> **Overview**
> Updates the `Claude Code` GitHub Actions workflow to let the Claude action read CI results by adding `checks: read` and `statuses: read` to the job permissions and to the action’s `additional_permissions`.
> 
> Also passes `github_token: ${{ github.token }}` into `anthropics/claude-code-action@v1` so it can authenticate with these permissions when running.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 73e31d70042faadee90f7302857ad9ccaf184816. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced continuous integration workflow configuration to improve integration with GitHub's CI checks and status tracking systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->